### PR TITLE
Add DEM-based AOI geolocation and context menu

### DIFF
--- a/app/core/controllers/MainWindow.py
+++ b/app/core/controllers/MainWindow.py
@@ -565,6 +565,11 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         if not isinstance(distance_unit, str):
             self.settings_service.set_setting('DistanceUnit', 'Meters')
 
+        dem_dir = self.settings_service.get_setting('DEMDirectory')
+        if not isinstance(dem_dir, str):
+            default_dem = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), '..', 'resources', 'dem'))
+            self.settings_service.set_setting('DEMDirectory', default_dem)
+
         theme = self.settings_service.get_setting('Theme')
         if theme is None:
             self.settings_service.set_setting('Theme', 'Dark')

--- a/app/core/controllers/Perferences.py
+++ b/app/core/controllers/Perferences.py
@@ -34,6 +34,7 @@ class Preferences(QDialog, Ui_Preferences):
         self.positionFormatComboBox.setCurrentText(self.parent.settings_service.get_setting('PositionFormat'))
         self.temperatureComboBox.setCurrentText(self.parent.settings_service.get_setting('TemperatureUnit'))
         self.distanceComboBox.setCurrentText(self.parent.settings_service.get_setting('DistanceUnit'))
+        self.demLineEdit.setText(self.parent.settings_service.get_setting('DEMDirectory'))
         drone_sensor_version = PickleHelper.get_drone_sensor_file_version()
         self.dronSensorVersionLabel.setText(f"{drone_sensor_version['Version']}_{drone_sensor_version['Date']}")
 
@@ -46,6 +47,8 @@ class Preferences(QDialog, Ui_Preferences):
         self.temperatureComboBox.currentTextChanged.connect(self._update_temperature_unit)
         self.distanceComboBox.currentTextChanged.connect(self._update_distance_unit)
         self.droneSensorButton.clicked.connect(self._droneSensorButton_clicked)
+        self.demBrowseButton.clicked.connect(self._demBrowseButton_clicked)
+        self.demLineEdit.textChanged.connect(self._update_dem_directory)
 
     def _update_max_aois(self):
         """Updates the maximum areas of interest setting based on the spinbox value."""
@@ -72,6 +75,17 @@ class Preferences(QDialog, Ui_Preferences):
     def _update_distance_unit(self):
         """Updates the distance unit setting based on the selected combobox value."""
         self.parent.settings_service.set_setting('DistanceUnit', self.distanceComboBox.currentText())
+
+    def _update_dem_directory(self):
+        """Updates the DEM directory path."""
+        self.parent.settings_service.set_setting('DEMDirectory', self.demLineEdit.text())
+
+    def _demBrowseButton_clicked(self):
+        """Opens a directory dialog for selecting DEM files."""
+        dir = self.demLineEdit.text() or self.parent.settings_service.get_setting('DEMDirectory') or ''
+        directory = QFileDialog.getExistingDirectory(self, "Select DEM Directory", dir, QFileDialog.ShowDirsOnly)
+        if directory:
+            self.demLineEdit.setText(directory)
 
     def _droneSensorButton_clicked(self):
         """

--- a/app/core/controllers/Viewer.py
+++ b/app/core/controllers/Viewer.py
@@ -9,7 +9,7 @@ import math
 import numpy as np
 from pathlib import Path
 from collections import UserDict, OrderedDict
-from PyQt5.QtGui import QImage, QIntValidator, QPixmap, QImageReader, QIcon, QMovie, QPainter, QFont, QPen, QPalette, QColor, QDesktopServices
+from PyQt5.QtGui import QImage, QIntValidator, QPixmap, QImageReader, QIcon, QMovie, QPainter, QFont, QPen, QPalette, QColor, QDesktopServices, QCursor
 from PyQt5.QtCore import Qt, QSize, QThread, pyqtSignal, QPointF, QEvent, QRect, QTimer, QUrl
 from PyQt5.QtWidgets import QDialog, QMainWindow, QMessageBox, QListWidgetItem, QFileDialog, QCheckBox, QMenu, QAction
 from PyQt5.QtWidgets import QPushButton, QFrame, QVBoxLayout, QLabel, QWidget, QAbstractButton, QHBoxLayout
@@ -28,6 +28,9 @@ from core.services.ZipBundleService import ZipBundleService
 from core.services.ImageService import ImageService
 from helpers.LocationInfo import LocationInfo
 from urllib.parse import quote_plus
+
+from core.services.AOILocationService import AOILocationService
+from core.services.SettingsService import SettingsService
 
 
 class Viewer(QMainWindow, Ui_Viewer):
@@ -472,6 +475,7 @@ class Viewer(QMainWindow, Ui_Viewer):
             self.aoiListWidget.setSpacing(5)
             self.highlights.append(highlight)
             highlight.leftMouseButtonPressed.connect(self._area_of_interest_click)
+            highlight.rightMouseButtonPressed.connect(lambda _x, _y, c=center: self._show_aoi_context_menu(c))
             count += 1
 
         self.areaCountLabel.setText(f"{count} {'Area' if count == 1 else 'Areas'} of Interest")
@@ -788,6 +792,43 @@ class Viewer(QMainWindow, Ui_Viewer):
         # Restore status text if Qt cleared it while the menu was open
         self._refresh_statusbar_message()
 
+    def _show_aoi_context_menu(self, center):
+        settings = SettingsService()
+        dem_dir = settings.get_setting('DEMDirectory')
+        service = AOILocationService(dem_dir)
+        image_path = self.images[self.current_image]['path']
+        result = service.compute_aoi_coordinates(image_path, center[0], center[1])
+        if result is None:
+            self._show_toast("AOI coordinates unavailable", 3000, color="#F44336")
+            return
+        lat, lon, alt = result
+        coord_text = self._format_position_string(lat, lon)
+
+        menu = QMenu(self)
+        menu.setFont(self.statusbar.font())
+
+        act_copy = QAction("Copy coordinates", self)
+        act_copy.triggered.connect(lambda: self._copy_coords_to_clipboard(coord_text))
+        menu.addAction(act_copy)
+
+        act_maps = QAction("Open in Google Maps", self)
+        act_maps.triggered.connect(lambda: self._open_coords_in_maps(lat, lon))
+        menu.addAction(act_maps)
+
+        act_earth = QAction("View in Google Earth", self)
+        act_earth.triggered.connect(lambda: self._open_aoi_in_earth(lat, lon, alt, center))
+        menu.addAction(act_earth)
+
+        act_wa = QAction("Send via WhatsApp", self)
+        act_wa.triggered.connect(lambda: self._share_whatsapp_coords(lat, lon))
+        menu.addAction(act_wa)
+
+        act_tg = QAction("Send via Telegram", self)
+        act_tg.triggered.connect(lambda: self._share_telegram_coords(lat, lon))
+        menu.addAction(act_tg)
+
+        menu.exec_(QCursor.pos())
+
     def _copy_coords_to_clipboard(self, coord_text=None):
         from PyQt5.QtWidgets import QApplication
         if coord_text is None:
@@ -799,14 +840,26 @@ class Viewer(QMainWindow, Ui_Viewer):
         self._show_toast("Coordinates copied", 3000, color="#00C853")
         self._refresh_statusbar_message()
 
+    def _format_position_string(self, lat, lon):
+        if self.position_format == 'Lat/Long - Decimal Degrees':
+            return f"{lat}, {lon}"
+        elif self.position_format == 'Lat/Long - Degrees, Minutes, Seconds':
+            dms = LocationInfo.convert_decimal_to_dms(lat, lon)
+            return (
+                f"{dms['latitude']['degrees']}°{dms['latitude']['minutes']}'{dms['latitude']['seconds']}\"{dms['latitude']['reference']} "
+                f"{dms['longitude']['degrees']}°{dms['longitude']['minutes']}'{dms['longitude']['seconds']}\"{dms['longitude']['reference']}"
+            )
+        else:
+            utm = LocationInfo.convert_degrees_to_utm(lat, lon)
+            return f"{utm['zone_number']}{utm['zone_letter']} {utm['easting']} {utm['northing']}"
+
     def _open_in_maps(self):
         lat_lon = self._get_decimals_or_parse()
         if not lat_lon:
             self._show_toast("Coordinates unavailable", 3000, color="#F44336")
             return
         lat, lon = lat_lon
-        url = QUrl(f"https://www.google.com/maps?q={lat},{lon}")
-        QDesktopServices.openUrl(url)
+        self._open_coords_in_maps(lat, lon)
         self._refresh_statusbar_message()
 
     def _open_in_earth(self):
@@ -876,10 +929,7 @@ class Viewer(QMainWindow, Ui_Viewer):
             self._show_toast("Coordinates unavailable", 3000, color="#F44336")
             return
         lat, lon = lat_lon
-        maps = f"https://www.google.com/maps?q={lat},{lon}"
-        text = f"Coordinate: {lat}, {lon} — {maps}"
-        wa_url = f"https://wa.me/?text={quote_plus(text)}"
-        QDesktopServices.openUrl(QUrl(wa_url))
+        self._share_whatsapp_coords(lat, lon)
         self._refresh_statusbar_message()
 
     def _share_telegram(self):
@@ -888,10 +938,80 @@ class Viewer(QMainWindow, Ui_Viewer):
             self._show_toast("Coordinates unavailable", 3000, color="#F44336")
             return
         lat, lon = lat_lon
+        self._share_telegram_coords(lat, lon)
+        self._refresh_statusbar_message()
+
+    def _open_coords_in_maps(self, lat, lon):
+        url = QUrl(f"https://www.google.com/maps?q={lat},{lon}")
+        QDesktopServices.openUrl(url)
+
+    def _share_whatsapp_coords(self, lat, lon):
+        maps = f"https://www.google.com/maps?q={lat},{lon}"
+        text = f"Coordinate: {lat}, {lon} — {maps}"
+        wa_url = f"https://wa.me/?text={quote_plus(text)}"
+        QDesktopServices.openUrl(QUrl(wa_url))
+
+    def _share_telegram_coords(self, lat, lon):
         maps = f"https://www.google.com/maps?q={lat},{lon}"
         tg_url = f"https://t.me/share/url?url={quote_plus(maps)}&text={quote_plus(f'Coordinates: {lat}, {lon}') }"
         QDesktopServices.openUrl(QUrl(tg_url))
-        self._refresh_statusbar_message()
+
+    def _open_aoi_in_earth(self, target_lat, target_lon, target_alt, center):
+        lat_lon = self._get_decimals_or_parse()
+        if not lat_lon:
+            self._show_toast("Coordinates unavailable", 3000, color="#F44336")
+            return
+        cam_lat, cam_lon = lat_lon
+        image_path = self.images[self.current_image]['path']
+        image_service = ImageService(image_path)
+        yaw, pitch = image_service.get_gimbal_orientation()
+        altitude = image_service.get_asl_altitude('m')
+        hfov = image_service.get_camera_hfov()
+
+        if yaw is None:
+            yaw = 0.0
+        if pitch is None:
+            pitch = -90.0
+        if altitude is None:
+            altitude = 100.0
+        if hfov is None:
+            hfov = 60.0
+
+        range_val = 50
+        tilt = max(0, min(180, 90 + pitch))
+
+        kml = (
+            "<?xml version='1.0' encoding='UTF-8'?>\n"
+            "<kml xmlns='http://www.opengis.net/kml/2.2'>\n"
+            "  <Document>\n"
+            "    <name>ADIAT View</name>\n"
+            "    <open>1</open>\n"
+            "    <LookAt>\n"
+            f"      <longitude>{cam_lon}</longitude>\n"
+            f"      <latitude>{cam_lat}</latitude>\n"
+            f"      <altitude>{altitude}</altitude>\n"
+            f"      <heading>{yaw}</heading>\n"
+            f"      <tilt>{tilt}</tilt>\n"
+            "      <altitudeMode>absolute</altitudeMode>\n"
+            f"      <range>{range_val}</range>\n"
+            "    </LookAt>\n"
+            "    <Placemark>\n"
+            "      <name>Photo Location</name>\n"
+            f"      <Point><coordinates>{cam_lon},{cam_lat},0</coordinates></Point>\n"
+            "    </Placemark>\n"
+            "    <Placemark>\n"
+            f"      <name>{center[0]}_{center[1]}</name>\n"
+            f"      <Point><coordinates>{target_lon},{target_lat},{target_alt}</coordinates></Point>\n"
+            "    </Placemark>\n"
+            "  </Document>\n"
+            "</kml>\n"
+        )
+
+        fd, kml_path = tempfile.mkstemp(suffix='.kml')
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            f.write(kml)
+
+        QDesktopServices.openUrl(QUrl.fromLocalFile(kml_path))
 
     def _get_decimals_or_parse(self):
         # Prefer decimal coords captured from EXIF

--- a/app/core/services/AOILocationService.py
+++ b/app/core/services/AOILocationService.py
@@ -1,0 +1,83 @@
+import math
+from typing import Optional, Tuple
+
+import piexif
+from pyproj import Geod
+
+from core.services.ImageService import ImageService
+from helpers.LocationInfo import LocationInfo
+from .DEMService import DEMService
+
+
+class AOILocationService:
+    """Compute geographic coordinates of an AOI by intersecting image rays with a DEM."""
+
+    def __init__(self, dem_directory: str):
+        self.dem_service = DEMService(dem_directory)
+        self.geod = Geod(ellps="WGS84")
+
+    def compute_aoi_coordinates(self, image_path: str, pixel_x: float, pixel_y: float) -> Optional[Tuple[float, float, float]]:
+        """Return (lat, lon, elevation) of the AOI center or None if unavailable."""
+        image_service = ImageService(image_path)
+        yaw, pitch = image_service.get_gimbal_orientation()
+        altitude = image_service.get_asl_altitude('m')
+        hfov = image_service.get_camera_hfov()
+        gps = LocationInfo.get_gps(exif_data=image_service.exif_data)
+
+        if None in (yaw, pitch, altitude, hfov) or not gps:
+            return None
+
+        width = image_service.exif_data['Exif'][piexif.ExifIFD.PixelXDimension]
+        height = image_service.exif_data['Exif'][piexif.ExifIFD.PixelYDimension]
+
+        vfov = 2 * math.atan(math.tan(math.radians(hfov / 2)) * height / width)
+        fx = width / (2 * math.tan(math.radians(hfov / 2)))
+        fy = height / (2 * math.tan(vfov / 2))
+        cx, cy = width / 2.0, height / 2.0
+
+        x_off = pixel_x - cx
+        y_off = pixel_y - cy
+        angle_x = math.degrees(math.atan2(x_off, fx))
+        angle_y = math.degrees(math.atan2(y_off, fy))
+
+        yaw_prime = yaw + angle_x
+        pitch_prime = pitch - angle_y
+        pitch_rad = math.radians(pitch_prime)
+
+        lat0, lon0 = gps['latitude'], gps['longitude']
+        alt0 = altitude
+
+        # Step along the ray until we hit terrain or reach 5 km
+        step = 10.0
+        max_dist = 5000.0
+        dist = 0.0
+        prev_lat = prev_lon = prev_alt_ray = prev_dem = None
+        azimuth = yaw_prime
+        while dist <= max_dist:
+            dist += step
+            lon, lat, _ = self.geod.fwd(lon0, lat0, azimuth, dist)
+            dem = self.dem_service.get_elevation(lat, lon)
+            if dem is None:
+                continue
+            alt_ray = alt0 + dist * math.tan(pitch_rad)
+            if alt_ray <= dem:
+                # binary refine between previous and current distances
+                left = dist - step
+                right = dist
+                for _ in range(10):
+                    mid = (left + right) / 2
+                    lon, lat, _ = self.geod.fwd(lon0, lat0, azimuth, mid)
+                    dem_mid = self.dem_service.get_elevation(lat, lon)
+                    alt_mid = alt0 + mid * math.tan(pitch_rad)
+                    if dem_mid is None:
+                        left = mid
+                        continue
+                    if alt_mid > dem_mid:
+                        left = mid
+                    else:
+                        right = mid
+                        dist = mid
+                        dem = dem_mid
+                return lat, lon, dem
+            prev_lat, prev_lon, prev_alt_ray, prev_dem = lat, lon, alt_ray, dem
+        return None

--- a/app/core/services/DEMService.py
+++ b/app/core/services/DEMService.py
@@ -1,0 +1,54 @@
+import os
+from typing import Optional
+
+import rasterio
+
+
+class DEMService:
+    """Service to query elevations from pre-downloaded DEM tiles.
+
+    The service lazily loads GeoTIFF files from a configured directory and
+    retrieves elevation values for geographic coordinates (lat, lon)."""
+
+    def __init__(self, dem_directory: str):
+        self.dem_directory = dem_directory
+        self._datasets = []
+
+    def _ensure_datasets_loaded(self) -> None:
+        if self._datasets or not self.dem_directory:
+            return
+        if not os.path.isdir(self.dem_directory):
+            return
+        for name in os.listdir(self.dem_directory):
+            if not name.lower().endswith('.tif'):
+                continue
+            path = os.path.join(self.dem_directory, name)
+            try:
+                ds = rasterio.open(path)
+                self._datasets.append(ds)
+            except Exception:
+                # Skip unreadable tiles
+                continue
+
+    def _get_dataset(self, lat: float, lon: float):
+        self._ensure_datasets_loaded()
+        for ds in self._datasets:
+            bounds = ds.bounds
+            if bounds.left <= lon <= bounds.right and bounds.bottom <= lat <= bounds.top:
+                return ds
+        return None
+
+    def get_elevation(self, lat: float, lon: float) -> Optional[float]:
+        """Return elevation in meters for the given latitude and longitude."""
+        ds = self._get_dataset(lat, lon)
+        if ds is None:
+            return None
+        try:
+            row, col = ds.index(lon, lat)
+            data = ds.read(1)
+            value = data[row, col]
+            if ds.nodata is not None and value == ds.nodata:
+                return None
+            return float(value)
+        except Exception:
+            return None

--- a/app/core/views/components/Preferences_ui.py
+++ b/app/core/views/components/Preferences_ui.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file 'C:\Users\charl\source\repos\crgrove\adiat_ai\resources/views/components\Preferences.ui'
+# Form implementation generated from reading ui file 'resources/views/components/Preferences.ui'
 #
 # Created by: PyQt5 UI code generator 5.15.11
 #
@@ -156,6 +156,30 @@ class Ui_Preferences(object):
         self.distanceComboBox.addItem("")
         self.horizontalLayout_7.addWidget(self.distanceComboBox)
         self.verticalLayout_2.addWidget(self.distanceWidget)
+        self.demWidget = QtWidgets.QWidget(self.mainWidget)
+        self.demWidget.setObjectName("demWidget")
+        self.horizontalLayout_dem = QtWidgets.QHBoxLayout(self.demWidget)
+        self.horizontalLayout_dem.setObjectName("horizontalLayout_dem")
+        self.demLabel = QtWidgets.QLabel(self.demWidget)
+        font = QtGui.QFont()
+        font.setPointSize(10)
+        self.demLabel.setFont(font)
+        self.demLabel.setObjectName("demLabel")
+        self.horizontalLayout_dem.addWidget(self.demLabel)
+        self.demLineEdit = QtWidgets.QLineEdit(self.demWidget)
+        font = QtGui.QFont()
+        font.setPointSize(10)
+        self.demLineEdit.setFont(font)
+        self.demLineEdit.setObjectName("demLineEdit")
+        self.horizontalLayout_dem.addWidget(self.demLineEdit)
+        self.demBrowseButton = QtWidgets.QPushButton(self.demWidget)
+        font = QtGui.QFont()
+        font.setPointSize(10)
+        self.demBrowseButton.setFont(font)
+        self.demBrowseButton.setAutoDefault(False)
+        self.demBrowseButton.setObjectName("demBrowseButton")
+        self.horizontalLayout_dem.addWidget(self.demBrowseButton)
+        self.verticalLayout_2.addWidget(self.demWidget)
         self.droneSensorLabelsWidget = QtWidgets.QHBoxLayout()
         self.droneSensorLabelsWidget.setContentsMargins(9, 9, 9, 9)
         self.droneSensorLabelsWidget.setObjectName("droneSensorLabelsWidget")
@@ -216,6 +240,8 @@ class Ui_Preferences(object):
         self.distanceLabel.setText(_translate("Preferences", "Distance Unit:"))
         self.distanceComboBox.setItemText(0, _translate("Preferences", "Meters"))
         self.distanceComboBox.setItemText(1, _translate("Preferences", "Feet"))
+        self.demLabel.setText(_translate("Preferences", "DEM Directory:"))
+        self.demBrowseButton.setText(_translate("Preferences", "Browse"))
         self.droneSensorLabel.setText(_translate("Preferences", "Drone Sensor File Version:"))
         self.dronSensorVersionLabel.setText(_translate("Preferences", "TextLabel"))
         self.droneSensorButton.setText(_translate("Preferences", "Replace"))

--- a/app/tests/algorithms/test_algorithm_service.py
+++ b/app/tests/algorithms/test_algorithm_service.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch, MagicMock, mock_open
-from app.algorithms.Algorithm import AlgorithmService
+from app.algorithms.AlgorithmService import AlgorithmService
 import cv2
 import numpy as np
 from pathlib import Path

--- a/app/tests/core/services/test_aoi_location_service.py
+++ b/app/tests/core/services/test_aoi_location_service.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.append('app')
+from core.services.AOILocationService import AOILocationService
+
+
+def test_compute_aoi_coordinates():
+    service = AOILocationService('resources/dem')
+    result = service.compute_aoi_coordinates('resources/img/DJI_20240908125346_0045_V.JPG', 2000, 1500)
+    assert result is not None
+    lat, lon, alt = result
+    assert 39.34 < lat < 39.35
+    assert 8.40 < lon < 8.41
+    assert alt > 0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,5 @@ qt5-tools
 PyInstaller
 pytest-qt
 flake8
+rasterio
+pyproj

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ utm
 PyExifTool
 reportlab
 onnxruntime-gpu==1.20.1
+rasterio
+pyproj

--- a/resources/views/components/Preferences.ui
+++ b/resources/views/components/Preferences.ui
@@ -192,8 +192,8 @@
        </widget>
       </item>
       <item>
-       <widget class="QWidget" name="TemperatureWidget" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_5">
+      <widget class="QWidget" name="TemperatureWidget" native="true">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
          <item>
           <widget class="QLabel" name="temperatureLabel">
            <property name="font">
@@ -258,10 +258,52 @@
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="droneSensorLabelsWidget">
+      </widget>
+     </item>
+     <item>
+      <widget class="QWidget" name="demWidget" native="true">
+       <layout class="QHBoxLayout" name="horizontalLayout_dem">
+        <item>
+         <widget class="QLabel" name="demLabel">
+          <property name="font">
+           <font>
+            <pointsize>10</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string>DEM Directory:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="demLineEdit">
+          <property name="font">
+           <font>
+            <pointsize>10</pointsize>
+           </font>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="demBrowseButton">
+          <property name="font">
+           <font>
+            <pointsize>10</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="droneSensorLabelsWidget">
         <property name="leftMargin">
          <number>9</number>
         </property>


### PR DESCRIPTION
## Summary
- compute AOI coordinates by intersecting camera rays with offline DEM data
- allow configuring DEM directory via Preferences and Settings
- add right-click AOI context menu with Google Earth waypoint support

## Testing
- `pytest` *(fails: ImportError and other errors)*
- `pytest app/tests/core/services/test_aoi_location_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0a0352880832988677629f7d74823